### PR TITLE
Add ListeningCancelled event

### DIFF
--- a/ApiAi.Android/SpeaktoitRecognitionService.cs
+++ b/ApiAi.Android/SpeaktoitRecognitionService.cs
@@ -152,6 +152,7 @@ namespace ApiAi.Android
             {
                 // Do nothing, because of request was cancelled in standard way
                 Log.Debug(TAG, "StartVoiceRequest - OperationCancelled");
+                new Task(OnListeningCancelled).Start();
             }
             catch (System.Exception e)
             {

--- a/ApiAi.Common/AIService.cs
+++ b/ApiAi.Common/AIService.cs
@@ -38,6 +38,8 @@ namespace ApiAi.Common
         public event Action ListeningStarted;
         public event Action ListeningFinished;
 
+        public event Action ListeningCancelled;
+
         public event Action<AIResponse> OnResult;
         public event Action<AIServiceException> OnError;
 
@@ -100,6 +102,11 @@ namespace ApiAi.Common
         {
             ListeningFinished.InvokeSafely();
         }
+        protected virtual void OnListeningCancelled()
+        {
+            ListeningCancelled.InvokeSafely();
+        }
+
 
         protected virtual void FireOnResult(AIResponse response)
         {


### PR DESCRIPTION
Allow consumer to know when Api.ai hasn't created a result, or has been cancelled

This is useful in the scenario when AiService_ListeningFinished event has been triggered, but no AiService_OnResult event has triggered i.e. we should be able to know when listening has finished but no result has been created (other than the error event) 

Therefore this commit is an event for the cancelled state, which appears in log file

> [SpeaktoitRecognitionService] StartVoiceRequest - OperationCancelled
